### PR TITLE
Update Rechiseled to fabric + Minecraft 1.21.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import java.util.regex.Pattern
 
 plugins {
-    id "fabric-loom" version "1.4-SNAPSHOT"
+    id "fabric-loom" version "1.7-SNAPSHOT"
     id "com.matthewprenger.cursegradle" version "1.4.0"
     id "com.modrinth.minotaur" version "2.+"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 # Minecraft
-minecraft_version=1.21
-minecraft_dependency=>=1.21 <1.22
-minecraft_suffix=mc1.21
+minecraft_version=1.21.1
+minecraft_dependency=>=1.21.1 <1.22
+minecraft_suffix=mc1.21.1
 java_target=21
 java_dependency=>=21
 resource_pack_format=34
@@ -38,14 +38,14 @@ maven_group=com.supermartijn642
 # CurseForge
 curseforge_project_id=854949
 curseforge_release_type=release
-curseforge_game_versions=1.21
+curseforge_game_versions=1.21.1
 curseforge_required_dependency_ids=fabric-api supermartijn642s-core-lib supermartijn642s-config-lib fusion-connected-textures
 curseforge_optional_dependency_ids=
 
 # Modrinth
 modrinth_project_id=fusion-connected-textures
 modrinth_release_type=release
-modrinth_game_versions=1.21
+modrinth_game_versions=1.21.1
 modrinth_required_dependency_ids=fabric-api supermartijn642s-core-lib supermartijn642s-config-lib fusion-connected-textures
 modrinth_optional_dependency_ids=
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,18 +3,18 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 # Minecraft
-minecraft_version=1.20.1
-minecraft_dependency=>=1.20 <1.21
-minecraft_suffix=mc1.20
-java_target=17
-java_dependency=>=17
-resource_pack_format=15
+minecraft_version=1.21
+minecraft_dependency=>=1.21 <1.22
+minecraft_suffix=mc1.21
+java_target=21
+java_dependency=>=21
+resource_pack_format=34
 
 # Fabric
-fabric_loader_version=0.14.22
-fabric_loader_dependency=>=0.14.0
-fabric_api_version=0.88.1+1.20.1
-fabric_api_dependency=*
+fabric_loader_version=0.15.11
+fabric_loader_dependency=>=0.15.11
+fabric_api_version=0.102.1+1.21.1
+fabric_api_dependency=>=0.102.1
 
 # Mixin
 mixin_minimum_version=0.8
@@ -36,25 +36,26 @@ mod_client_class=RechiseledClient
 maven_group=com.supermartijn642
 
 # CurseForge
-curseforge_project_id=558998
+curseforge_project_id=854949
 curseforge_release_type=release
-curseforge_game_versions=1.20 1.20.1
+curseforge_game_versions=1.21
 curseforge_required_dependency_ids=fabric-api supermartijn642s-core-lib supermartijn642s-config-lib fusion-connected-textures
-curseforge_optional_dependency_ids=jei
+curseforge_optional_dependency_ids=
 
 # Modrinth
-modrinth_project_id=rechiseled
+modrinth_project_id=fusion-connected-textures
 modrinth_release_type=release
-modrinth_game_versions=1.20 1.20.1
+modrinth_game_versions=1.21
 modrinth_required_dependency_ids=fabric-api supermartijn642s-core-lib supermartijn642s-config-lib fusion-connected-textures
 modrinth_optional_dependency_ids=
 
 # Dependencies
-core_library_file=4666040
-core_library_dependency=>=1.1.0 <1.2.0
-config_library_file=4629803
-config_library_dependency=>=1.1.0
+core_library_file=5627732
+core_library_dependency=>=1.1.17+b <1.2.0
+config_library_file=5546988
+config_library_dependency=>=1.1.8
+# TODO update this when fusion:fabric-1.21.1 is available
 fusion_file=5129312
 fusion_dependency=>=1.0.0
-just_enough_items_file=4574527
+just_enough_items_file=5628160
 just_enough_items_class=compat.jei.ChiselingJEIPlugin

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/supermartijn642/rechiseled/ChiselItem.java
+++ b/src/main/java/com/supermartijn642/rechiseled/ChiselItem.java
@@ -4,17 +4,26 @@ import com.supermartijn642.core.CommonUtils;
 import com.supermartijn642.core.item.BaseItem;
 import com.supermartijn642.core.item.ItemProperties;
 import com.supermartijn642.rechiseled.screen.ChiselContainer;
-import net.minecraft.nbt.CompoundTag;
+import net.minecraft.core.Registry;
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.core.component.TypedDataComponent;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+
 /**
  * Created 25/12/2021 by SuperMartijn642
  */
 public class ChiselItem extends BaseItem {
+    public static final DataComponentType<ItemStack> CHISEL_STACK = register("chisel_stack",
+            (builder) -> builder.persistent(ItemStack.CODEC).networkSynchronized(ItemStack.STREAM_CODEC).cacheEncoding());
 
     public ChiselItem(){
         super(ItemProperties.create().maxStackSize(1).group(Rechiseled.GROUP));
@@ -29,15 +38,25 @@ public class ChiselItem extends BaseItem {
     }
 
     public static ItemStack getStoredStack(ItemStack chisel){
-        CompoundTag tag = chisel.getOrCreateTag();
-        return tag.contains("stack") ? ItemStack.of(tag.getCompound("stack")) : ItemStack.EMPTY;
+        Optional<TypedDataComponent<?>> stack = chisel.getComponents().filter(dct -> dct == CHISEL_STACK).stream().findFirst();
+        if (stack.isPresent()) {
+            return (ItemStack)stack.get().value();
+        } else {
+            return ItemStack.EMPTY;
+        }
     }
 
     public static void setStoredStack(ItemStack chisel, ItemStack stack){
-        CompoundTag tag = chisel.getOrCreateTag();
-        if(stack == null || stack.isEmpty())
-            tag.remove("stack");
-        else
-            tag.put("stack", stack.save(new CompoundTag()));
+        DataComponentMap dataComponents = chisel.getComponents();
+        if(stack == null || stack.isEmpty()) {
+            chisel.applyComponents(dataComponents.filter(dct -> dct != CHISEL_STACK));
+        } else {
+            chisel.applyComponents(DataComponentMap.composite(dataComponents, DataComponentMap.builder().set(CHISEL_STACK, stack).build()));
+        }
+    }
+
+    private static <T> DataComponentType<T> register(String string, UnaryOperator<DataComponentType.Builder<T>> unaryOperator) {
+        DataComponentType<T> dataComponentType = ((DataComponentType.Builder)unaryOperator.apply(DataComponentType.builder())).build();
+        return Registry.register(BuiltInRegistries.DATA_COMPONENT_TYPE, string, dataComponentType);
     }
 }

--- a/src/main/java/com/supermartijn642/rechiseled/ChiselItemRenderer.java
+++ b/src/main/java/com/supermartijn642/rechiseled/ChiselItemRenderer.java
@@ -42,7 +42,7 @@ public class ChiselItemRenderer implements CustomItemRenderer {
                 MatrixUtil.mulComponentWise(pose.pose(), 0.5f);
             else if(transformType.firstPerson())
                 MatrixUtil.mulComponentWise(pose.pose(), 0.75f);
-            vertexConsumer = ItemRenderer.getCompassFoilBufferDirect(bufferSource, renderType, pose);
+            vertexConsumer = ItemRenderer.getCompassFoilBuffer(bufferSource, renderType, pose);
             poseStack.popPose();
         }else
             vertexConsumer = ItemRenderer.getFoilBufferDirect(bufferSource, renderType, true, stack.hasFoil());

--- a/src/main/java/com/supermartijn642/rechiseled/api/BaseChiselingRecipes.java
+++ b/src/main/java/com/supermartijn642/rechiseled/api/BaseChiselingRecipes.java
@@ -55,6 +55,6 @@ public class BaseChiselingRecipes {
     public static final ResourceLocation WARPED_PLANKS = location("warped_planks");
 
     private static ResourceLocation location(String name){
-        return new ResourceLocation("rechiseled", name);
+        return ResourceLocation.fromNamespaceAndPath("rechiseled", name);
     }
 }

--- a/src/main/java/com/supermartijn642/rechiseled/api/ChiseledTextureProvider.java
+++ b/src/main/java/com/supermartijn642/rechiseled/api/ChiseledTextureProvider.java
@@ -84,12 +84,12 @@ public abstract class ChiseledTextureProvider implements DataProvider {
     }
 
     private Pair<BufferedImage,JsonObject> loadTexture(ResourceLocation location){
-        ResourceLocation fullLocation = new ResourceLocation(location.getNamespace(), "textures/" + location.getPath() + ".png");
+        ResourceLocation fullLocation = ResourceLocation.fromNamespaceAndPath(location.getNamespace(), "textures/" + location.getPath() + ".png");
         if(!TextureMappingTool.exists(fullLocation))
             throw new IllegalStateException("Could not find existing texture: " + location);
 
         // Get the metadata
-        ResourceLocation metadataLocation = new ResourceLocation(location.getNamespace(), "textures/" + location.getPath() + ".png.mcmeta");
+        ResourceLocation metadataLocation = ResourceLocation.fromNamespaceAndPath(location.getNamespace(), "textures/" + location.getPath() + ".png.mcmeta");
         boolean hasMetadata = TextureMappingTool.exists(metadataLocation);
         JsonObject metadata = null;
         if(hasMetadata){
@@ -135,7 +135,7 @@ public abstract class ChiseledTextureProvider implements DataProvider {
     }
 
     private boolean validateTexture(ResourceLocation texture){
-        ResourceLocation fullLocation = new ResourceLocation(texture.getNamespace(), "textures/" + texture.getPath() + ".png");
+        ResourceLocation fullLocation = ResourceLocation.fromNamespaceAndPath(texture.getNamespace(), "textures/" + texture.getPath() + ".png");
         return TextureMappingTool.exists(fullLocation);
     }
 
@@ -188,10 +188,10 @@ public abstract class ChiseledTextureProvider implements DataProvider {
         if(!ChiseledTextureProvider.this.outputLocations.add(outputLocation))
             throw new IllegalStateException("Two or more textures have the same output location: " + outputLocation);
 
-        PaletteMap paletteMap = this.createPaletteMap(new ResourceLocation("minecraft", "block/oak_planks"), plankTexture);
+        PaletteMap paletteMap = this.createPaletteMap(ResourceLocation.fromNamespaceAndPath("minecraft", "block/oak_planks"), plankTexture);
 
         for(String suffix : this.oakPlankSuffixes){
-            paletteMap.applyToTexture(new ResourceLocation("rechiseled", "block/oak_planks" + suffix), outputLocation + suffix);
+            paletteMap.applyToTexture(ResourceLocation.fromNamespaceAndPath("rechiseled", "block/oak_planks" + suffix), outputLocation + suffix);
         }
     }
 

--- a/src/main/java/com/supermartijn642/rechiseled/api/ChiselingRecipeProvider.java
+++ b/src/main/java/com/supermartijn642/rechiseled/api/ChiselingRecipeProvider.java
@@ -109,7 +109,7 @@ public abstract class ChiselingRecipeProvider implements DataProvider {
      * @return a chiseling recipe builder for the given recipe name
      */
     protected ChiselingRecipeBuilder beginRecipe(String recipeName){
-        return this.recipes.computeIfAbsent(new ResourceLocation(this.modid, recipeName), s -> new ChiselingRecipeBuilder());
+        return this.recipes.computeIfAbsent(ResourceLocation.fromNamespaceAndPath(this.modid, recipeName), s -> new ChiselingRecipeBuilder());
     }
 
     protected ChiselingRecipeBuilder beginRecipe(ResourceLocation recipe){

--- a/src/main/java/com/supermartijn642/rechiseled/blocks/RechiseledBlock.java
+++ b/src/main/java/com/supermartijn642/rechiseled/blocks/RechiseledBlock.java
@@ -6,8 +6,6 @@ import com.supermartijn642.core.block.BlockProperties;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.BlockGetter;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Consumer;
 
@@ -24,7 +22,7 @@ public class RechiseledBlock extends BaseBlock {
     }
 
     @Override
-    protected void appendItemInformation(ItemStack stack, @Nullable BlockGetter level, Consumer<Component> info, boolean advanced){
+    protected void appendItemInformation(ItemStack stack, Consumer<Component> info, boolean advanced) {
         if(this.connecting)
             info.accept(TextComponents.translation("rechiseled.tooltip.connecting").color(ChatFormatting.GRAY).get());
     }

--- a/src/main/java/com/supermartijn642/rechiseled/blocks/RechiseledBlockBuilderImpl.java
+++ b/src/main/java/com/supermartijn642/rechiseled/blocks/RechiseledBlockBuilderImpl.java
@@ -147,7 +147,7 @@ public class RechiseledBlockBuilderImpl implements RechiseledBlockBuilder {
     public RechiseledBlockBuilderImpl blockTag(String namespace, String identifier){
         if(this.completed)
             throw new RuntimeException("Builder has already been build!");
-        this.tags.add(new ResourceLocation(namespace, identifier));
+        this.tags.add(ResourceLocation.fromNamespaceAndPath(namespace, identifier));
         return this;
     }
 
@@ -238,7 +238,7 @@ public class RechiseledBlockBuilderImpl implements RechiseledBlockBuilder {
 
         // Create the block type
         RechiseledBlockTypeImpl blockType = new RechiseledBlockTypeImpl(
-            new ResourceLocation(this.registration.getModid(), this.identifier),
+                ResourceLocation.fromNamespaceAndPath(this.registration.getModid(), this.identifier),
             this.specification,
             this.hasRegularVariant,
             this.hasConnectingVariant,

--- a/src/main/java/com/supermartijn642/rechiseled/chiseling/ChiselingRecipe.java
+++ b/src/main/java/com/supermartijn642/rechiseled/chiseling/ChiselingRecipe.java
@@ -58,7 +58,7 @@ public class ChiselingRecipe {
 
             // read parent id
             String parentRecipeString = GsonHelper.getAsString(json, "parent", null); // TODO remove in 1.2.0
-            ResourceLocation parentRecipe = parentRecipeString == null ? null : new ResourceLocation(parentRecipeString);
+            ResourceLocation parentRecipe = parentRecipeString == null ? null : ResourceLocation.parse(parentRecipeString);
 
             // Read overwrite value
             boolean overwrite = GsonHelper.getAsBoolean(json, "overwrite", false);
@@ -81,7 +81,7 @@ public class ChiselingRecipe {
                 if(regularItemName.isEmpty())
                     regularItem = null;
                 else{
-                    regularItem = Registries.ITEMS.getValue(new ResourceLocation(regularItemName));
+                    regularItem = Registries.ITEMS.getValue(ResourceLocation.parse(regularItemName));
                     if(regularItem == null && !optional)
                         throw new JsonParseException("Unknown item '" + regularItemName + "'");
                 }
@@ -90,7 +90,7 @@ public class ChiselingRecipe {
                 if(connectingItemName.isEmpty())
                     connectingItem = null;
                 else{
-                    connectingItem = Registries.ITEMS.getValue(new ResourceLocation(connectingItemName));
+                    connectingItem = Registries.ITEMS.getValue(ResourceLocation.parse(connectingItemName));
                     if(connectingItem == null && !optional)
                         throw new JsonParseException("Unknown item '" + connectingItemName + "'");
                 }

--- a/src/main/java/com/supermartijn642/rechiseled/chiseling/ChiselingRecipeLoader.java
+++ b/src/main/java/com/supermartijn642/rechiseled/chiseling/ChiselingRecipeLoader.java
@@ -43,7 +43,7 @@ public class ChiselingRecipeLoader implements PreparableReloadListener, Identifi
 
     @Override
     public ResourceLocation getFabricId(){
-        return new ResourceLocation("rechiseled", "chiseling_recipe_loader");
+        return ResourceLocation.fromNamespaceAndPath("rechiseled", "chiseling_recipe_loader");
     }
 
     @Override

--- a/src/main/java/com/supermartijn642/rechiseled/compat/jei/ChiselingJEIPlugin.java
+++ b/src/main/java/com/supermartijn642/rechiseled/compat/jei/ChiselingJEIPlugin.java
@@ -22,7 +22,7 @@ public class ChiselingJEIPlugin implements IModPlugin {
 
     @Override
     public ResourceLocation getPluginUid(){
-        return new ResourceLocation("rechiseled", "chiseling_plugin");
+        return ResourceLocation.fromNamespaceAndPath("rechiseled", "chiseling_plugin");
     }
 
     @Override

--- a/src/main/java/com/supermartijn642/rechiseled/compat/jei/ChiselingRecipeCategory.java
+++ b/src/main/java/com/supermartijn642/rechiseled/compat/jei/ChiselingRecipeCategory.java
@@ -28,7 +28,7 @@ public class ChiselingRecipeCategory implements IRecipeCategory<ChiselingRecipe>
     private final IDrawable icon;
 
     public ChiselingRecipeCategory(IGuiHelper guiHelper){
-        this.backgrounds = guiHelper.createDrawable(new ResourceLocation("rechiseled", "textures/screen/jei_category_background.png"), 0, 0, 174, 72);
+        this.backgrounds = guiHelper.createDrawable(ResourceLocation.fromNamespaceAndPath("rechiseled", "textures/screen/jei_category_background.png"), 0, 0, 174, 72);
         this.icon = guiHelper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(Rechiseled.chisel));
     }
 

--- a/src/main/java/com/supermartijn642/rechiseled/data/RechiseledItemModelGenerator.java
+++ b/src/main/java/com/supermartijn642/rechiseled/data/RechiseledItemModelGenerator.java
@@ -17,6 +17,6 @@ public class RechiseledItemModelGenerator extends ModelGenerator {
     @Override
     public void generate(){
         // Chisel
-        this.itemHandheld(Rechiseled.chisel, new ResourceLocation("rechiseled", "item/chisel"));
+        this.itemHandheld(Rechiseled.chisel, ResourceLocation.fromNamespaceAndPath("rechiseled", "item/chisel"));
     }
 }

--- a/src/main/java/com/supermartijn642/rechiseled/data/RechiseledTextureProvider.java
+++ b/src/main/java/com/supermartijn642/rechiseled/data/RechiseledTextureProvider.java
@@ -15,15 +15,15 @@ public class RechiseledTextureProvider extends ChiseledTextureProvider {
 
     @Override
     protected void createTextures(){
-        this.createPlankTextures(new ResourceLocation("minecraft", "block/acacia_planks"), "block/acacia_planks");
-        this.createPlankTextures(new ResourceLocation("minecraft", "block/birch_planks"), "block/birch_planks");
-        this.createPlankTextures(new ResourceLocation("minecraft", "block/crimson_planks"), "block/crimson_planks");
-        this.createPlankTextures(new ResourceLocation("minecraft", "block/dark_oak_planks"), "block/dark_oak_planks");
-        this.createPlankTextures(new ResourceLocation("minecraft", "block/jungle_planks"), "block/jungle_planks");
-        this.createPlankTextures(new ResourceLocation("minecraft", "block/mangrove_planks"), "block/mangrove_planks");
-        this.createPlankTextures(new ResourceLocation("minecraft", "block/spruce_planks"), "block/spruce_planks");
-        this.createPlankTextures(new ResourceLocation("minecraft", "block/warped_planks"), "block/warped_planks");
-        this.createPlankTextures(new ResourceLocation("minecraft", "block/bamboo_planks"), "block/bamboo_planks");
-        this.createPlankTextures(new ResourceLocation("minecraft", "block/cherry_planks"), "block/cherry_planks");
+        this.createPlankTextures(ResourceLocation.fromNamespaceAndPath("minecraft", "block/acacia_planks"), "block/acacia_planks");
+        this.createPlankTextures(ResourceLocation.fromNamespaceAndPath("minecraft", "block/birch_planks"), "block/birch_planks");
+        this.createPlankTextures(ResourceLocation.fromNamespaceAndPath("minecraft", "block/crimson_planks"), "block/crimson_planks");
+        this.createPlankTextures(ResourceLocation.fromNamespaceAndPath("minecraft", "block/dark_oak_planks"), "block/dark_oak_planks");
+        this.createPlankTextures(ResourceLocation.fromNamespaceAndPath("minecraft", "block/jungle_planks"), "block/jungle_planks");
+        this.createPlankTextures(ResourceLocation.fromNamespaceAndPath("minecraft", "block/mangrove_planks"), "block/mangrove_planks");
+        this.createPlankTextures(ResourceLocation.fromNamespaceAndPath("minecraft", "block/spruce_planks"), "block/spruce_planks");
+        this.createPlankTextures(ResourceLocation.fromNamespaceAndPath("minecraft", "block/warped_planks"), "block/warped_planks");
+        this.createPlankTextures(ResourceLocation.fromNamespaceAndPath("minecraft", "block/bamboo_planks"), "block/bamboo_planks");
+        this.createPlankTextures(ResourceLocation.fromNamespaceAndPath("minecraft", "block/cherry_planks"), "block/cherry_planks");
     }
 }

--- a/src/main/java/com/supermartijn642/rechiseled/registration/data/RegistrationFusionModelProvider.java
+++ b/src/main/java/com/supermartijn642/rechiseled/registration/data/RegistrationFusionModelProvider.java
@@ -46,36 +46,36 @@ public class RegistrationFusionModelProvider extends FusionModelProvider {
         String identifier = Registries.BLOCKS.getIdentifier(block).getPath();
         if(modelType == BlockModelType.CUBE){
             ConnectingModelDataBuilder builder = ConnectingModelDataBuilder.builder()
-                .parent(new ResourceLocation("minecraft", "block/cube"))
-                .texture("up", new ResourceLocation(namespace, "block/" + texture + "_up"))
-                .texture("down", new ResourceLocation(namespace, "block/" + texture + "_down"))
-                .texture("north", new ResourceLocation(namespace, "block/" + texture + "_north"))
-                .texture("east", new ResourceLocation(namespace, "block/" + texture + "_east"))
-                .texture("south", new ResourceLocation(namespace, "block/" + texture + "_south"))
-                .texture("west", new ResourceLocation(namespace, "block/" + texture + "_west"))
-                .texture("particle", new ResourceLocation(namespace, "block/" + texture + "_up"));
+                .parent(ResourceLocation.fromNamespaceAndPath("minecraft", "block/cube"))
+                .texture("up", ResourceLocation.fromNamespaceAndPath(namespace, "block/" + texture + "_up"))
+                .texture("down", ResourceLocation.fromNamespaceAndPath(namespace, "block/" + texture + "_down"))
+                .texture("north", ResourceLocation.fromNamespaceAndPath(namespace, "block/" + texture + "_north"))
+                .texture("east", ResourceLocation.fromNamespaceAndPath(namespace, "block/" + texture + "_east"))
+                .texture("south", ResourceLocation.fromNamespaceAndPath(namespace, "block/" + texture + "_south"))
+                .texture("west", ResourceLocation.fromNamespaceAndPath(namespace, "block/" + texture + "_west"))
+                .texture("particle", ResourceLocation.fromNamespaceAndPath(namespace, "block/" + texture + "_up"));
             ModelInstance<?> model = ModelInstance.of(DefaultModelTypes.CONNECTING, builder.build());
-            this.addModel(new ResourceLocation(namespace, "block/" + identifier), model);
+            this.addModel(ResourceLocation.fromNamespaceAndPath(namespace, "block/" + identifier), model);
         }else if(modelType == BlockModelType.CUBE_ALL){
             ConnectingModelDataBuilder builder = ConnectingModelDataBuilder.builder()
-                .parent(new ResourceLocation("minecraft", "block/cube_all"))
-                .texture("all", new ResourceLocation(namespace, "block/" + texture))
+                .parent(ResourceLocation.fromNamespaceAndPath("minecraft", "block/cube_all"))
+                .texture("all", ResourceLocation.fromNamespaceAndPath(namespace, "block/" + texture))
                 .connection(DefaultConnectionPredicates.isSameBlock());
             ModelInstance<?> model = ModelInstance.of(DefaultModelTypes.CONNECTING, builder.build());
-            this.addModel(new ResourceLocation(namespace, "block/" + identifier), model);
+            this.addModel(ResourceLocation.fromNamespaceAndPath(namespace, "block/" + identifier), model);
         }else if(modelType == BlockModelType.PILLAR){
             ConnectingModelDataBuilder builder = ConnectingModelDataBuilder.builder()
-                .parent(new ResourceLocation("minecraft", "block/cube"))
-                .texture("up", new ResourceLocation(namespace, "block/" + texture + "_end"))
-                .texture("down", new ResourceLocation(namespace, "block/" + texture + "_end"))
-                .texture("north", new ResourceLocation(namespace, "block/" + texture + "_side"))
-                .texture("east", new ResourceLocation(namespace, "block/" + texture + "_side"))
-                .texture("south", new ResourceLocation(namespace, "block/" + texture + "_side"))
-                .texture("west", new ResourceLocation(namespace, "block/" + texture + "_side"))
-                .texture("particle", new ResourceLocation(namespace, "block/" + texture + "_side"))
+                .parent(ResourceLocation.fromNamespaceAndPath("minecraft", "block/cube"))
+                .texture("up", ResourceLocation.fromNamespaceAndPath(namespace, "block/" + texture + "_end"))
+                .texture("down", ResourceLocation.fromNamespaceAndPath(namespace, "block/" + texture + "_end"))
+                .texture("north", ResourceLocation.fromNamespaceAndPath(namespace, "block/" + texture + "_side"))
+                .texture("east", ResourceLocation.fromNamespaceAndPath(namespace, "block/" + texture + "_side"))
+                .texture("south", ResourceLocation.fromNamespaceAndPath(namespace, "block/" + texture + "_side"))
+                .texture("west", ResourceLocation.fromNamespaceAndPath(namespace, "block/" + texture + "_side"))
+                .texture("particle", ResourceLocation.fromNamespaceAndPath(namespace, "block/" + texture + "_side"))
                 .connection(DefaultConnectionPredicates.isSameState());
             ModelInstance<?> model = ModelInstance.of(DefaultModelTypes.CONNECTING, builder.build());
-            this.addModel(new ResourceLocation(namespace, "block/" + identifier), model);
+            this.addModel(ResourceLocation.fromNamespaceAndPath(namespace, "block/" + identifier), model);
         }
     }
 

--- a/src/main/java/com/supermartijn642/rechiseled/registration/data/RegistrationLootTableGenerator.java
+++ b/src/main/java/com/supermartijn642/rechiseled/registration/data/RegistrationLootTableGenerator.java
@@ -36,8 +36,8 @@ public class RegistrationLootTableGenerator extends LootTableGenerator {
 
     private void addLootTable(Block block){
         ResourceLocation identifier = Registries.BLOCKS.getIdentifier(block);
-        ResourceLocation lootTable = block.getLootTable();
-        if(lootTable == null || (lootTable.getNamespace().equals(identifier.getNamespace()) && lootTable.getPath().equals("block/" + identifier.getPath())))
+        ResourceLocation lootTable = block.getLootTable().location();
+        if(lootTable.getNamespace().equals(identifier.getNamespace()) && lootTable.getPath().equals("block/" + identifier.getPath()))
             return;
         this.dropSelf(block);
     }

--- a/src/main/java/com/supermartijn642/rechiseled/screen/BaseChiselingContainer.java
+++ b/src/main/java/com/supermartijn642/rechiseled/screen/BaseChiselingContainer.java
@@ -117,11 +117,11 @@ public abstract class BaseChiselingContainer extends BaseContainer {
         for(int index = 0; index < inventory.getContainerSize(); index++){
             ItemStack stack = inventory.getItem(index);
             Item item = this.connecting ? this.currentEntry.getConnectingItem() : this.currentEntry.getRegularItem();
-            if(stack.getCount() > item.getMaxStackSize())
+            if(stack.getCount() > item.getDefaultMaxStackSize())
                 continue;
 
             for(ChiselingEntry entry : this.currentRecipe.getEntries()){
-                if((!stack.hasTag() || stack.getTag().isEmpty())
+                if((stack.getTags().findAny().isEmpty())
                     && ((entry.hasConnectingItem() && stack.getItem() == entry.getConnectingItem())
                     || (entry.hasRegularItem() && stack.getItem() == entry.getRegularItem()))){
                     stack = new ItemStack(item, stack.getCount());
@@ -174,7 +174,7 @@ public abstract class BaseChiselingContainer extends BaseContainer {
 
                 Slot slot = this.slots.get(index);
                 ItemStack slotStack = slot.getItem();
-                if(!slotStack.isEmpty() && ItemStack.isSameItemSameTags(stack, slotStack)){
+                if(!slotStack.isEmpty() && ItemStack.isSameItemSameComponents(stack, slotStack)){
                     int sumCount = slotStack.getCount() + stack.getCount();
                     int maxSize = Math.min(slot.getMaxStackSize(), stack.getMaxStackSize());
                     if(sumCount <= maxSize){

--- a/src/main/java/com/supermartijn642/rechiseled/screen/BaseChiselingContainerScreen.java
+++ b/src/main/java/com/supermartijn642/rechiseled/screen/BaseChiselingContainerScreen.java
@@ -24,7 +24,7 @@ import java.util.function.Supplier;
  */
 public class BaseChiselingContainerScreen<T extends BaseChiselingContainer> extends BaseContainerWidget<T> {
 
-    private static final ResourceLocation BACKGROUND = new ResourceLocation("rechiseled", "textures/screen/chiseling_background.png");
+    private static final ResourceLocation BACKGROUND = ResourceLocation.fromNamespaceAndPath("rechiseled", "textures/screen/chiseling_background.png");
 
     /**
      * 0 - 1 block
@@ -97,7 +97,7 @@ public class BaseChiselingContainerScreen<T extends BaseChiselingContainer> exte
                 ItemStack stack = slot.getItem();
 
                 for(ChiselingEntry entry : this.container.currentRecipe.getEntries()){
-                    if((!stack.hasTag() || stack.getTag().isEmpty())
+                    if(stack.getTags().findAny().isEmpty()
                         && ((entry.hasConnectingItem() && stack.getItem() == entry.getConnectingItem())
                         || (entry.hasRegularItem() && stack.getItem() == entry.getRegularItem()))){
                         ScreenUtils.fillRect(context.poseStack(), slot.x, slot.y, 16, 16, 0, 20, 100, 0.5f);

--- a/src/main/java/com/supermartijn642/rechiseled/screen/ChiselAllWidget.java
+++ b/src/main/java/com/supermartijn642/rechiseled/screen/ChiselAllWidget.java
@@ -17,8 +17,8 @@ import java.util.function.Supplier;
  */
 public class ChiselAllWidget extends AbstractButtonWidget {
 
-    private static final ResourceLocation GREY_BUTTONS = new ResourceLocation("rechiseled", "textures/screen/grey_buttons.png");
-    private static final ResourceLocation CHISEL_TEXTURE = new ResourceLocation("rechiseled", "textures/item/chisel.png");
+    private static final ResourceLocation GREY_BUTTONS = ResourceLocation.fromNamespaceAndPath("rechiseled", "textures/screen/grey_buttons.png");
+    private static final ResourceLocation CHISEL_TEXTURE = ResourceLocation.fromNamespaceAndPath("rechiseled", "textures/item/chisel.png");
 
     private final Supplier<ChiselingEntry> currentEntry;
 

--- a/src/main/java/com/supermartijn642/rechiseled/screen/ConnectingToggleWidget.java
+++ b/src/main/java/com/supermartijn642/rechiseled/screen/ConnectingToggleWidget.java
@@ -18,9 +18,9 @@ import java.util.function.Supplier;
  */
 public class ConnectingToggleWidget extends AbstractButtonWidget {
 
-    private static final ResourceLocation GREY_BUTTONS = new ResourceLocation("rechiseled", "textures/screen/grey_buttons.png");
-    private static final ResourceLocation ICON_CONNECTED_ON = new ResourceLocation("rechiseled", "textures/screen/icon_connecting_true.png");
-    private static final ResourceLocation ICON_CONNECTED_OFF = new ResourceLocation("rechiseled", "textures/screen/icon_connecting_false.png");
+    private static final ResourceLocation GREY_BUTTONS = ResourceLocation.fromNamespaceAndPath("rechiseled", "textures/screen/grey_buttons.png");
+    private static final ResourceLocation ICON_CONNECTED_ON = ResourceLocation.fromNamespaceAndPath("rechiseled", "textures/screen/icon_connecting_true.png");
+    private static final ResourceLocation ICON_CONNECTED_OFF = ResourceLocation.fromNamespaceAndPath("rechiseled", "textures/screen/icon_connecting_false.png");
 
     private final Supplier<Boolean> connecting;
     private final Supplier<ChiselingEntry> currentEntry;

--- a/src/main/java/com/supermartijn642/rechiseled/screen/EntryButtonWidget.java
+++ b/src/main/java/com/supermartijn642/rechiseled/screen/EntryButtonWidget.java
@@ -16,7 +16,7 @@ import java.util.function.Supplier;
  */
 public class EntryButtonWidget extends BaseWidget {
 
-    private static final ResourceLocation TEXTURE = new ResourceLocation("rechiseled", "textures/screen/buttons.png");
+    private static final ResourceLocation TEXTURE = ResourceLocation.fromNamespaceAndPath("rechiseled", "textures/screen/buttons.png");
 
     private final Supplier<ChiselingEntry> entry;
     private final Supplier<ChiselingEntry> selectedEntry;

--- a/src/main/java/com/supermartijn642/rechiseled/screen/PreviewModeButtonWidget.java
+++ b/src/main/java/com/supermartijn642/rechiseled/screen/PreviewModeButtonWidget.java
@@ -14,19 +14,19 @@ import java.util.function.Supplier;
  */
 public class PreviewModeButtonWidget extends AbstractButtonWidget {
 
-    private static final ResourceLocation GREY_BUTTONS = new ResourceLocation("rechiseled", "textures/screen/grey_buttons.png");
+    private static final ResourceLocation GREY_BUTTONS = ResourceLocation.fromNamespaceAndPath("rechiseled", "textures/screen/grey_buttons.png");
     private static final ResourceLocation[][] ICONS = {
         {
-            new ResourceLocation("rechiseled", "textures/screen/icon_1x1.png"),
-            new ResourceLocation("rechiseled", "textures/screen/icon_1x1_grey.png")
+            ResourceLocation.fromNamespaceAndPath("rechiseled", "textures/screen/icon_1x1.png"),
+            ResourceLocation.fromNamespaceAndPath("rechiseled", "textures/screen/icon_1x1_grey.png")
         },
         {
-            new ResourceLocation("rechiseled", "textures/screen/icon_3x1.png"),
-            new ResourceLocation("rechiseled", "textures/screen/icon_3x1_grey.png")
+            ResourceLocation.fromNamespaceAndPath("rechiseled", "textures/screen/icon_3x1.png"),
+            ResourceLocation.fromNamespaceAndPath("rechiseled", "textures/screen/icon_3x1_grey.png")
         },
         {
-            new ResourceLocation("rechiseled", "textures/screen/icon_3x3.png"),
-            new ResourceLocation("rechiseled", "textures/screen/icon_3x3_grey.png")
+            ResourceLocation.fromNamespaceAndPath("rechiseled", "textures/screen/icon_3x3.png"),
+            ResourceLocation.fromNamespaceAndPath("rechiseled", "textures/screen/icon_3x3_grey.png")
         }
     };
 

--- a/src/main/java/com/supermartijn642/rechiseled/screen/ScreenBlockRenderer.java
+++ b/src/main/java/com/supermartijn642/rechiseled/screen/ScreenBlockRenderer.java
@@ -37,13 +37,13 @@ public class ScreenBlockRenderer {
 
         poseStack.pushPose();
         poseStack.translate(x, y, 350);
-        poseStack.mulPoseMatrix(new Matrix4f().scaling(1.0F, -1.0F, 1.0F));
+        poseStack.mulPose(new Matrix4f().scaling(1.0F, -1.0F, 1.0F));
         poseStack.scale((float)scale, (float)scale, (float)scale);
         poseStack.mulPose(new Quaternionf().setAngleAxis(pitch / 180 * (float)Math.PI, 1, 0, 0));
         poseStack.mulPose(new Quaternionf().setAngleAxis(yaw / 180 * (float)Math.PI, 0, 1, 0));
 
         if(doShading)
-            Lighting.setupLevel(new Matrix4f().rotateX((float)(Math.PI / 3)).rotateY((float)(Math.PI / 2)));
+            Lighting.setupForEntityInInventory(new Quaternionf().rotateX((float) (Math.PI / 2)).rotateZ((float) (Math.PI)));
 
         MultiBufferSource.BufferSource renderTypeBuffer = RenderUtils.getMainBufferSource();
         for(Map.Entry<BlockPos,BlockState> entry : capture.getBlocks())

--- a/src/main/java/com/supermartijn642/rechiseled/screen/ToggleRotationButton.java
+++ b/src/main/java/com/supermartijn642/rechiseled/screen/ToggleRotationButton.java
@@ -11,7 +11,7 @@ import net.minecraft.resources.ResourceLocation;
  */
 public class ToggleRotationButton extends AbstractButtonWidget {
 
-    private static final ResourceLocation TEXTURE = new ResourceLocation("rechiseled", "textures/screen/rotation_icon.png");
+    private static final ResourceLocation TEXTURE = ResourceLocation.fromNamespaceAndPath("rechiseled", "textures/screen/rotation_icon.png");
 
     public static boolean rotate = true;
 

--- a/src/main/resources/modid.accesswidener
+++ b/src/main/resources/modid.accesswidener
@@ -9,7 +9,7 @@ accessible field net/minecraft/client/renderer/block/model/BlockModel parent Lne
 accessible field net/minecraft/client/renderer/block/model/BlockModel parentLocation Lnet/minecraft/resources/ResourceLocation;
 accessible field net/minecraft/client/renderer/block/model/BlockModel textureMap Ljava/util/Map;
 accessible field net/minecraft/client/renderer/block/model/BlockModel transforms Lnet/minecraft/client/renderer/block/model/ItemTransforms;
-accessible method net/minecraft/client/renderer/block/model/BlockModel bakeFace (Lnet/minecraft/client/renderer/block/model/BlockElement;Lnet/minecraft/client/renderer/block/model/BlockElementFace;Lnet/minecraft/client/renderer/texture/TextureAtlasSprite;Lnet/minecraft/core/Direction;Lnet/minecraft/client/resources/model/ModelState;Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/client/renderer/block/model/BakedQuad;
+accessible method net/minecraft/client/renderer/block/model/BlockModel bake (Lnet/minecraft/client/resources/model/ModelBaker;Lnet/minecraft/client/renderer/block/model/BlockModel;Ljava/util/function/Function;Lnet/minecraft/client/resources/model/ModelState;Z)Lnet/minecraft/client/resources/model/BakedModel;
 accessible method net/minecraft/client/renderer/block/model/BlockModel findTextureEntry (Ljava/lang/String;)Lcom/mojang/datafixers/util/Either;
 # ItemRenderer
 accessible method net/minecraft/client/renderer/entity/ItemRenderer renderModelLists (Lnet/minecraft/client/resources/model/BakedModel;Lnet/minecraft/world/item/ItemStack;IILcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;)V
@@ -22,5 +22,3 @@ accessible class net/minecraft/client/renderer/block/model/ItemTransform$Deseria
 accessible field net/minecraft/client/Minecraft resourcePackRepository Lnet/minecraft/server/packs/repository/PackRepository;
 # ServerPacksSource
 accessible method net/minecraft/server/packs/repository/ServerPacksSource createVanillaPackSource ()Lnet/minecraft/server/packs/VanillaPackResources;
-# VertexFormat
-accessible field com/mojang/blaze3d/vertex/VertexFormat offsets Lit/unimi/dsi/fastutil/ints/IntList;


### PR DESCRIPTION
This uses the Fusion code in https://github.com/SuperMartijn642/Fusion/pull/80 , built locally.  

The chisel seems to work correctly.  The only difference I can tell is that shift-doubleclicking a chisel when you have a chest open, doesn't move all the chisels with matching contents to the chest / inventory.  I suspect this means the new DataComponents are somehow not equal across different item instances, but I can't figure out how to verify that or fix it.  

I had to update the lighting to use Quaternion instead of Matrix, and the lighting didn't look the same after.  So I had to mess with the angle of it some.  I think I matched it decently well, but I certainly wouldn't be offended by further tweaking.  